### PR TITLE
fix: Fix builds in latest GitHub environments

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -419,6 +419,31 @@ jobs:
           make
           # No "make install" for ffmpeg.
 
+      - name: Prepare assets
+        run: |
+          set -e
+          set -x
+
+          mkdir assets
+          SUFFIX="-${{ matrix.os_name }}-${{ matrix.target_arch }}${{ matrix.exe_ext}}"
+          echo "SUFFIX=$SUFFIX" >> "$GITHUB_ENV"
+          cp ffmpeg/ffmpeg assets/ffmpeg"$SUFFIX"
+          cp ffmpeg/ffprobe assets/ffprobe"$SUFFIX"
+
+          # Show sizes and MD5 sums that can be verified by users later if they
+          # want to check for authenticity.
+          cd assets
+          wc -c *
+          md5sum *
+
+      # This makes it possible to debug failures in the next step by
+      # downloading binaries that fail the check for static linkage.
+      - name: Upload assets as artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries-${{ env.SUFFIX }}
+          path: assets/*
+
       - name: Check that executables are static
         run: |
           set -e
@@ -451,22 +476,6 @@ jobs:
           # above), we still need a successful command at the end of the script
           # to make this step of the workflow a success.
           true
-
-      - name: Prepare assets
-        run: |
-          set -e
-          set -x
-
-          mkdir assets
-          SUFFIX="-${{ matrix.os_name }}-${{ matrix.target_arch }}${{ matrix.exe_ext}}"
-          cp ffmpeg/ffmpeg assets/ffmpeg"$SUFFIX"
-          cp ffmpeg/ffprobe assets/ffprobe"$SUFFIX"
-
-          # Show sizes and MD5 sums that can be verified by users later if they
-          # want to check for authenticity.
-          cd assets
-          wc -c *
-          md5sum *
 
       - name: Attach assets to release
         if: inputs.release_id != ''

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -127,9 +127,15 @@ jobs:
           # static library builds below.  They are still installed, but will no
           # longer be symlinked into default library paths, and the ffmpeg
           # build will not pick up pre-installed shared libraries we don't want.
-          # Only our static versions will be used.
+          # Only our static versions will be used.  The list of preinstalled
+          # packages in the GitHub Actions environment may change over time, so
+          # this list may need to change, as well.
           brew unlink \
+            aom \
             lame \
+            libxau \
+            libxcb \
+            libxdmcp \
             opus \
             opusfile \
             xz
@@ -153,8 +159,17 @@ jobs:
           set -x
 
           # Install msys packages we will need.
+          # NOTE: Add tools to this list if you see errors like
+          # "shared_info::initialize: size of shared memory region changed".
+          # The tools reporting such errors need to be explicitly replaced by
+          # msys versions.  The list of preinstalled packages in the GitHub
+          # Actions environment may change over time, so this list may need to
+          # change, as well.
           pacman -Sy --noconfirm \
+            diffutils \
+            gcc \
             git \
+            make \
             mercurial \
             nasm \
             yasm
@@ -203,8 +218,12 @@ jobs:
 
           # NOTE: without CMAKE_INSTALL_PREFIX on Windows, files are installed
           # to c:\Program Files.
+          # NOTE: without CMAKE_INSTALL_LIBDIR on Linux, pkgconfig and static
+          # libs are installed to /usr/local/lib/x86_64-linux-gnu/ instead of
+          # /usr/local/lib/.
           cmake ../aom \
             -DCMAKE_INSTALL_PREFIX=/usr/local \
+            -DCMAKE_INSTALL_LIBDIR=lib \
             -DENABLE_DOCS=OFF \
             -DENABLE_EXAMPLES=OFF \
             -DENABLE_TESTS=OFF \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -158,6 +158,15 @@ jobs:
           set -e
           set -x
 
+          # NOTE: pacman is hanging, and the best workaround seems to be to
+          # downgrade it and use --ignore pacman below to keep it from being
+          # re-upgraded.
+          # See https://github.com/msys2/msys2.github.io/issues/82
+          wget http://repo.msys2.org/msys/x86_64/pacman-5.2.2-19-x86_64.pkg.tar.zst
+          zstd -d pacman-5.2.2-19-x86_64.pkg.tar.zst -o pacman-5.2.2-19-x86_64.pkg.tar
+          tar -xvf pacman-5.2.2-19-x86_64.pkg.tar --strip-components 2 usr/bin/pacman.exe
+          cp pacman.exe /usr/bin/pacman.exe
+
           # Install msys packages we will need.
           # NOTE: Add tools to this list if you see errors like
           # "shared_info::initialize: size of shared memory region changed".
@@ -165,8 +174,6 @@ jobs:
           # msys versions.  The list of preinstalled packages in the GitHub
           # Actions environment may change over time, so this list may need to
           # change, as well.
-          # NOTE: --ignore pacman works around a hang detailed in
-          # https://github.com/msys2/msys2.github.io/issues/82
           pacman -Sy --noconfirm \
             --ignore pacman \
             diffutils \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -165,7 +165,10 @@ jobs:
           # msys versions.  The list of preinstalled packages in the GitHub
           # Actions environment may change over time, so this list may need to
           # change, as well.
+          # NOTE: --ignore pacman works around a hang detailed in
+          # https://github.com/msys2/msys2.github.io/issues/82
           pacman -Sy --noconfirm \
+            --ignore pacman \
             diffutils \
             gcc \
             git \
@@ -441,7 +444,7 @@ jobs:
       - name: Upload assets as artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: binaries-${{ env.SUFFIX }}
+          name: binaries${{ env.SUFFIX }}
           path: assets/*
 
       - name: Check that executables are static

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -165,16 +165,6 @@ jobs:
           set -e
           set -x
 
-          # NOTE: pacman is hanging, and the best workaround seems to be to
-          # downgrade it and use --ignore pacman below to keep it from being
-          # re-upgraded.
-          # See https://github.com/msys2/msys2.github.io/issues/82
-          pacman --version
-          wget http://repo.msys2.org/msys/x86_64/pacman-5.2.2-19-x86_64.pkg.tar.zst
-          zstd -d pacman-5.2.2-19-x86_64.pkg.tar.zst -o pacman-5.2.2-19-x86_64.pkg.tar
-          tar -xvf pacman-5.2.2-19-x86_64.pkg.tar --strip-components 2 usr/bin/pacman.exe
-          cp pacman.exe /usr/bin/pacman.exe
-
           # Install msys packages we will need.
           # NOTE: Add tools to this list if you see errors like
           # "shared_info::initialize: size of shared memory region changed".
@@ -183,9 +173,7 @@ jobs:
           # Actions environment may change over time, so this list may need to
           # change, as well.
           pacman -Sy --noconfirm \
-            --ignore pacman \
             diffutils \
-            gcc \
             git \
             make \
             mercurial \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -169,6 +169,7 @@ jobs:
           # downgrade it and use --ignore pacman below to keep it from being
           # re-upgraded.
           # See https://github.com/msys2/msys2.github.io/issues/82
+          pacman --version
           wget http://repo.msys2.org/msys/x86_64/pacman-5.2.2-19-x86_64.pkg.tar.zst
           zstd -d pacman-5.2.2-19-x86_64.pkg.tar.zst -o pacman-5.2.2-19-x86_64.pkg.tar
           tar -xvf pacman-5.2.2-19-x86_64.pkg.tar --strip-components 2 usr/bin/pacman.exe
@@ -512,8 +513,8 @@ jobs:
             upload-all-assets "$release_id" assets/
 
       # NOTE: Uncomment this step to debug failures via SSH.
-      #- name: Debug
-      #  uses: mxschmitt/action-tmate@v3.6
-      #  with:
-      #    limit-access-to-actor: true
-      #  if: failure()
+      - name: Debug
+        uses: mxschmitt/action-tmate@v3.6
+        with:
+          limit-access-to-actor: true
+        if: failure()

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -355,6 +355,7 @@ jobs:
           # This flag is needed when building on Windows.
           if [[ "${{ runner.os }}" == "Windows" ]]; then
             export WINDOWS_BUILD=1
+            export CC=gcc
           fi
 
           # NOTE: The library is built statically unless SHARED environment
@@ -501,8 +502,8 @@ jobs:
             upload-all-assets "$release_id" assets/
 
       # NOTE: Uncomment this step to debug failures via SSH.
-      - name: Debug
-        uses: mxschmitt/action-tmate@v3.6
-        with:
-          limit-access-to-actor: true
-        if: failure()
+      #- name: Debug
+      #  uses: mxschmitt/action-tmate@v3.6
+      #  with:
+      #    limit-access-to-actor: true
+      #  if: failure()

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -129,16 +129,23 @@ jobs:
           # build will not pick up pre-installed shared libraries we don't want.
           # Only our static versions will be used.  The list of preinstalled
           # packages in the GitHub Actions environment may change over time, so
-          # this list may need to change, as well.
-          brew unlink \
+          # this list may need to change, as well.  Ignore errors if one of
+          # these is not installed.
+          for i in \
             aom \
             lame \
+            libvpx \
             libxau \
             libxcb \
             libxdmcp \
+            mbedtls \
             opus \
             opusfile \
-            xz
+            svt-av1 \
+            x264 \
+            x265 \
+            xz \
+          ; do brew unlink $i || true; done
 
           # Use sudo in install commands on macOS.
           echo "SUDO=sudo" >> "$GITHUB_ENV"


### PR DESCRIPTION
This fixes several (but not quite all) issues with building in GitHub Actions environments:

 - macOS: Unlink additional conflicting libraries now installed by default through homebrew
 - Windows: Install msys tools that _used_ to be installed by default, but now need msys versions to be explicitly installed
 - Windows: Drop gcc from update list to avoid hanging while installing packages (not sure why this works)
 - Linux: Fix location of libaom pkg-config file
 - All: Upload artifacts before checking them, so that the binaries can be debugged if they fail a later check

Remaining issues:
 - FFmpeg build can't find libaom on Windows... but I plan to remove aom shortly.