### PR TITLE
ci: Fix ENABLE_DEBUG flag always interpreted as true

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -526,4 +526,7 @@ jobs:
         uses: mxschmitt/action-tmate@v3.6
         with:
           limit-access-to-actor: true
-        if: failure() && needs.matrix_config.outputs.ENABLE_DEBUG != ''
+        # NOTE: You cannot refer to secrets directly here when this workflow is
+        # called from another.
+        # NOTE: The ENABLE_DEBUG flag has been converted into "true" or "false".
+        if: failure() && needs.matrix_config.outputs.ENABLE_DEBUG == 'true'


### PR DESCRIPTION
When we process the flag through JS, then print it, it becomes "true" or "false".  But we compared it to "".

The processing turns out to be necessary, since you can't refer to secrets directly when build.yaml is called from another workflow like test.yaml.  So we just fix the condition to check for "true".