### PR TITLE
feat: Disable nvenc on Linux

### DIFF
--- a/build-scripts/08-ffmpeg.sh
+++ b/build-scripts/08-ffmpeg.sh
@@ -27,7 +27,7 @@ if [[ "$RUNNER_OS" == "Linux" ]]; then
   export LDFLAGS="-static"
 
   # Enable platform-specific hardware acceleration.
-  PLATFORM_CONFIGURE_FLAGS="--enable-nvenc --enable-vdpau"
+  PLATFORM_CONFIGURE_FLAGS="--enable-vdpau"
 elif [[ "$RUNNER_OS" == "macOS" ]]; then
   export CFLAGS="-static"
   # You can't do a _truly_ static build on macOS except the kernel.


### PR DESCRIPTION
This seems to require dynamic libraries, and the static build with nvenc does not seem to be portable.  Linux users who want hardware acceleration with nvenc may have to use another FFmpeg binary, such as one built from source or the one provided by their Linux distro.  With the addition of SVT-AV1 for fast software encoding, this should not be a huge deal.