### PR TITLE
ci: Log dynamic library dependencies

### DIFF
--- a/build-scripts/09-check-static.sh
+++ b/build-scripts/09-check-static.sh
@@ -26,26 +26,31 @@ if [[ "$RUNNER_OS" == "Linux" ]]; then
   ldd ffprobe && exit 1
 elif [[ "$RUNNER_OS" == "Windows" ]]; then
   # These will still be dynamic executables.
-  # Log the full list of DLL dependencies, for debugging.
-  ldd ffmpeg.exe
-  ldd ffprobe.exe
+  # Capture the full list of DLL dependencies, then log it for debugging.
+  ffmpeg_deps=$(ldd ffmpeg.exe)
+  ffprobe_deps=$(ldd ffprobe.exe)
+  echo "$ffmpeg_deps"
+  echo "$ffprobe_deps"
 
   # These should not link against anything outside of /c/Windows.  The grep
   # command will succeed if it can find anything outside /c/Windows, and then
   # we fail if that succeeds.
-  ldd ffmpeg.exe | grep -qvi /c/Windows/ && exit 1
-  ldd ffprobe.exe | grep -qvi /c/Windows/ && exit 1
+  echo "$ffmpeg_deps" | grep -qvi /c/Windows/ && exit 1
+  echo "$ffprobe_deps" | grep -qvi /c/Windows/ && exit 1
 elif [[ "$RUNNER_OS" == "macOS" ]]; then
   # These will still be dynamic executables.
-  # Log the full list of dynamic library dependencies, for debugging.
-  otool -L ffmpeg
-  otool -L ffprobe
+  # Capture the full list of dynamic library dependencies, the log it for
+  # debugging.
+  ffmpeg_deps=$(otool -L ffmpeg)
+  ffprobe_deps=$(otool -L ffprobe)
+  echo "$ffmpeg_deps"
+  echo "$ffprobe_deps"
 
   # These should not link against anything outside of /usr/lib or
   # /System/Library.  The grep command will succeed if it can find anything
   # outside these two folders, and then we fail if that succeeds.
-  otool -L ffmpeg | grep '\t' | grep -Evq '(/System/Library|/usr/lib)' && exit 1
-  otool -L ffprobe | grep '\t' | grep -Evq '(/System/Library|/usr/lib)' && exit 1
+  echo "$ffmpeg_deps" | grep '\t' | grep -Evq '(/System/Library|/usr/lib)' && exit 1
+  echo "$ffprobe_deps" | grep '\t' | grep -Evq '(/System/Library|/usr/lib)' && exit 1
 fi
 
 # After commands that we expect to fail (greps and ldd commands

--- a/build-scripts/09-check-static.sh
+++ b/build-scripts/09-check-static.sh
@@ -26,11 +26,10 @@ if [[ "$RUNNER_OS" == "Linux" ]]; then
   ldd ffprobe && exit 1
 elif [[ "$RUNNER_OS" == "Windows" ]]; then
   # These will still be dynamic executables.
-  # Capture the full list of DLL dependencies, then log it for debugging.
+  # Capture the full list of DLL dependencies.
+  # With set -x, this also gets logged.
   ffmpeg_deps=$(ldd ffmpeg.exe)
   ffprobe_deps=$(ldd ffprobe.exe)
-  echo "$ffmpeg_deps"
-  echo "$ffprobe_deps"
 
   # These should not link against anything outside of /c/Windows.  The grep
   # command will succeed if it can find anything outside /c/Windows, and then
@@ -39,12 +38,10 @@ elif [[ "$RUNNER_OS" == "Windows" ]]; then
   echo "$ffprobe_deps" | grep -qvi /c/Windows/ && exit 1
 elif [[ "$RUNNER_OS" == "macOS" ]]; then
   # These will still be dynamic executables.
-  # Capture the full list of dynamic library dependencies, the log it for
-  # debugging.
+  # Capture the full list of dynamic library dependencies.
+  # With set -x, this also gets logged.
   ffmpeg_deps=$(otool -L ffmpeg)
   ffprobe_deps=$(otool -L ffprobe)
-  echo "$ffmpeg_deps"
-  echo "$ffprobe_deps"
 
   # These should not link against anything outside of /usr/lib or
   # /System/Library.  The grep command will succeed if it can find anything

--- a/build-scripts/09-check-static.sh
+++ b/build-scripts/09-check-static.sh
@@ -21,21 +21,29 @@ cd ffmpeg
 
 if [[ "$RUNNER_OS" == "Linux" ]]; then
   # If ldd succeeds, then these are dynamic executables, so we fail
-  # this step if ldd succeeds.
+  # this step if ldd succeeds.  The output of ldd will still be logged.
   ldd ffmpeg && exit 1
   ldd ffprobe && exit 1
 elif [[ "$RUNNER_OS" == "Windows" ]]; then
-  # These will still be dynamic executables, but they should not link
-  # against anything outside of /c/Windows.  The grep command will
-  # succeed if it can find anything outside /c/Windows, and then we
-  # fail if that succeeds.
+  # These will still be dynamic executables.
+  # Log the full list of DLL dependencies, for debugging.
+  ldd ffmpeg.exe
+  ldd ffprobe.exe
+
+  # These should not link against anything outside of /c/Windows.  The grep
+  # command will succeed if it can find anything outside /c/Windows, and then
+  # we fail if that succeeds.
   ldd ffmpeg.exe | grep -qvi /c/Windows/ && exit 1
   ldd ffprobe.exe | grep -qvi /c/Windows/ && exit 1
 elif [[ "$RUNNER_OS" == "macOS" ]]; then
-  # These will still be dynamic executables, but they should not link
-  # against anything outside of /usr/lib or /System/Library.  The
-  # grep command will succeed if it can find anything outside
-  # these two folders, and then we fail if that succeeds.
+  # These will still be dynamic executables.
+  # Log the full list of dynamic library dependencies, for debugging.
+  otool -L ffmpeg
+  otool -L ffprobe
+
+  # These should not link against anything outside of /usr/lib or
+  # /System/Library.  The grep command will succeed if it can find anything
+  # outside these two folders, and then we fail if that succeeds.
   otool -L ffmpeg | grep '\t' | grep -Evq '(/System/Library|/usr/lib)' && exit 1
   otool -L ffprobe | grep '\t' | grep -Evq '(/System/Library|/usr/lib)' && exit 1
 fi


### PR DESCRIPTION
This should help in debugging non-portable binaries.