### PR TITLE
ci: Use repository variables instead of secrets

### DIFF
--- a/.github/workflows/build-matrix.json
+++ b/.github/workflows/build-matrix.json
@@ -21,7 +21,7 @@
     }
   ],
 
-  "comment2": "runners hosted by the owner, enabled by the ENABLE_SELF_HOSTED secret being set on the repo",
+  "comment2": "runners hosted by the owner, enabled by the ENABLE_SELF_HOSTED variable being set on the repo",
   "selfHosted": [
     {
       "os": "self-hosted-linux-arm64",

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,13 +30,6 @@ on:
       # So we call our secret parameter simply TOKEN.
       TOKEN:
         required: false
-      # These below are not actual secrets, but secrets are the only place to
-      # keep repo-specific configs that make this project friendlier to forks
-      # and easier to debug.
-      ENABLE_DEBUG:
-        required: true
-      ENABLE_SELF_HOSTED:
-        required: true
 
   # Runs on manual trigger.
   workflow_dispatch:
@@ -56,7 +49,7 @@ jobs:
   # Configure the build matrix based on inputs.  The list of objects in the
   # build matrix contents can't be changed by conditionals, but it can be
   # computed by another job and deserialized.  This uses
-  # secrets.ENABLE_SELF_HOSTED to determine the build matrix, based on the
+  # env.ENABLE_SELF_HOSTED to determine the build matrix, based on the
   # metadata in build-matrix.json.
   matrix_config:
     runs-on: ubuntu-latest
@@ -73,8 +66,8 @@ jobs:
         shell: node {0}
         run: |
           const fs = require('fs');
-          const enableDebug = "${{ secrets.ENABLE_DEBUG }}" != '';
-          const enableSelfHosted = "${{ secrets.ENABLE_SELF_HOSTED }}" != '';
+          const enableDebug = "${{ env.ENABLE_DEBUG }}" != '';
+          const enableSelfHosted = "${{ env.ENABLE_SELF_HOSTED }}" != '';
 
           // Use ENABLE_SELF_HOSTED to decide what the build matrix below
           // should include.
@@ -291,7 +284,4 @@ jobs:
         uses: mxschmitt/action-tmate@v3.6
         with:
           limit-access-to-actor: true
-        # NOTE: You cannot refer to secrets directly here when this workflow is
-        # called from another.
-        # NOTE: The ENABLE_DEBUG flag has been converted into "true" or "false".
-        if: failure() && needs.matrix_config.outputs.ENABLE_DEBUG == 'true'
+        if: failure() && env.ENABLE_DEBUG != ''

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,6 +67,11 @@ jobs:
           const fs = require('fs');
           const enableDebug = "${{ vars.ENABLE_DEBUG }}" != '';
           const enableSelfHosted = "${{ vars.ENABLE_SELF_HOSTED }}" != '';
+          console.log({
+            vars: '${{ toJSON(vars) }}',
+            env: '${{ toJSON(env) }}',
+            inputs: '${{ toJSON(inputs) }}',
+          });
 
           // Use ENABLE_SELF_HOSTED to decide what the build matrix below
           // should include.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,16 +46,15 @@ defaults:
     shell: bash
 
 jobs:
-  # Configure the build matrix based on inputs.  The list of objects in the
-  # build matrix contents can't be changed by conditionals, but it can be
+  # Configure the build matrix based on repo variables.  The list of objects in
+  # the build matrix contents can't be changed by conditionals, but it can be
   # computed by another job and deserialized.  This uses
-  # env.ENABLE_SELF_HOSTED to determine the build matrix, based on the
+  # vars.ENABLE_SELF_HOSTED to determine the build matrix, based on the
   # metadata in build-matrix.json.
   matrix_config:
     runs-on: ubuntu-latest
     outputs:
       MATRIX: ${{ steps.configure.outputs.MATRIX }}
-      ENABLE_DEBUG: ${{ steps.configure.outputs.ENABLE_DEBUG }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -66,8 +65,8 @@ jobs:
         shell: node {0}
         run: |
           const fs = require('fs');
-          const enableDebug = "${{ env.ENABLE_DEBUG }}" != '';
-          const enableSelfHosted = "${{ env.ENABLE_SELF_HOSTED }}" != '';
+          const enableDebug = "${{ vars.ENABLE_DEBUG }}" != '';
+          const enableSelfHosted = "${{ vars.ENABLE_SELF_HOSTED }}" != '';
 
           // Use ENABLE_SELF_HOSTED to decide what the build matrix below
           // should include.
@@ -85,7 +84,7 @@ jobs:
               `ENABLE_DEBUG=${ enableDebug }\n`);
 
           // Log the outputs, for the sake of debugging this script.
-          console.log({enableDebug, matrix});
+          console.log({enableDebug, enableSelfHosted, matrix});
 
   # On several different hosts, build ffmpeg's dependencies, then ffmpeg itself.
   # The deps are all built as static libraries.
@@ -284,4 +283,4 @@ jobs:
         uses: mxschmitt/action-tmate@v3.6
         with:
           limit-access-to-actor: true
-        if: failure() && env.ENABLE_DEBUG != ''
+        if: failure() && vars.ENABLE_DEBUG != ''

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,9 +23,9 @@ on:
     tags:
       - "*"
 
-# NOTE: Set the repository secret ENABLE_DEBUG to enable debugging via tmate on
+# NOTE: Set the repository variable ENABLE_DEBUG to enable debugging via tmate on
 # failure.
-# NOTE: Set the repository secret ENABLE_SELF_HOSTED to enable self-hosted
+# NOTE: Set the repository variable ENABLE_SELF_HOSTED to enable self-hosted
 # runners such as linux-arm64.  This is set on the official repo, but forks
 # will have to opt in after setting up their own self-hosted runners.
 
@@ -65,8 +65,6 @@ jobs:
       release_id: ${{ needs.draft_release.outputs.release_id }}
     secrets:
       TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      ENABLE_DEBUG: ${{ secrets.ENABLE_DEBUG }}
-      ENABLE_SELF_HOSTED: ${{ secrets.ENABLE_SELF_HOSTED }}
 
   publish_release:
     name: Publish release

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,9 +16,11 @@
 name: Test
 
 # Runs when a PR is uploaded or revised.  Builds ffmpeg and ffprobe on all OS &
-# CPU combinations.
+# CPU combinations.  Uses pull_request_target rather than pull_request for
+# access to configuration variables.  Since no secrets are accessed or passed
+# to the build workflow, this is safe.  Only the release workflow uses secrets.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 # If another instance of this workflow is started for the same PR, cancel the

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,15 +28,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# NOTE: Set the repository secret ENABLE_DEBUG to enable debugging via tmate on
-# failure.
-# NOTE: Set the repository secret ENABLE_SELF_HOSTED to enable self-hosted
+# NOTE: Set the repository variable ENABLE_DEBUG to enable debugging via tmate
+# on failure.
+# NOTE: Set the repository variable ENABLE_SELF_HOSTED to enable self-hosted
 # runners such as linux-arm64.  This is set on the official repo, but forks
 # will have to opt in after setting up their own self-hosted runners.
 
 jobs:
   build:
     uses: ./.github/workflows/build.yaml
-    secrets:
-      ENABLE_DEBUG: ${{ secrets.ENABLE_DEBUG }}
-      ENABLE_SELF_HOSTED: ${{ secrets.ENABLE_SELF_HOSTED }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,5 +35,17 @@ concurrency:
 # will have to opt in after setting up their own self-hosted runners.
 
 jobs:
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Debug
+        run: |
+          echo 'vars: ${{ toJSON(vars) }}'
+          echo 'env: ${{ toJSON(env) }}'
+          echo 'runner: ${{ toJSON(runner) }}'
+          echo 'github: ${{ toJSON(github) }}'
+          echo 'job: ${{ toJSON(job) }}'
+
   build:
+    needs: debug
     uses: ./.github/workflows/build.yaml


### PR DESCRIPTION
This new feature of GitHub was introduced in January 2023, and gives us an easy way to configure the repo without abusing the secrets system.  Secrets are not available to PR contexts (for good reason), so our secret-based configs also did not work on PRs.  By moving to the repo variable system, we solve that problem.

https://github.blog/changelog/2023-01-10-github-actions-support-for-configuration-variables-in-workflows/