### PR TITLE
fix: Fix Windows install paths of all deps

### DIFF
--- a/build-scripts/02-svt-av1.sh
+++ b/build-scripts/02-svt-av1.sh
@@ -23,7 +23,10 @@ git clone --depth 1 https://gitlab.com/AOMediaCodec/SVT-AV1 -b "$tag"
 mkdir SVT-AV1-build
 cd SVT-AV1-build
 
+# NOTE: without CMAKE_INSTALL_PREFIX on Windows, files are installed
+# to c:\Program Files.
 cmake ../SVT-AV1 \
+  -DCMAKE_INSTALL_PREFIX=/usr/local \
   -DBUILD_SHARED_LIBS=OFF \
   -DBUILD_TESTING=OFF \
   -DCOVERAGE=OFF \

--- a/build-scripts/06-opus.sh
+++ b/build-scripts/06-opus.sh
@@ -21,7 +21,10 @@ tag=$(repo-src/get-version.sh opus)
 git clone --depth 1 https://github.com/xiph/opus -b "$tag"
 cd opus
 
+# NOTE: without CMAKE_INSTALL_PREFIX on Windows, files are installed
+# to c:\Program Files.
 cmake . \
+  -DCMAKE_INSTALL_PREFIX=/usr/local \
   -DOPUS_BUILD_SHARED_LIBRARY=OFF \
   -DOPUS_BUILD_FRAMEWORK=OFF \
   -DBUILD_SHARED_LIBS=OFF \

--- a/build-scripts/07-mbedtls.sh
+++ b/build-scripts/07-mbedtls.sh
@@ -22,13 +22,14 @@ git clone --depth 1 https://github.com/ARMmbed/mbedtls.git -b "$tag"
 
 cd mbedtls
 
-# This flag is needed when building on Windows.
-if [[ "$RUNNER_OS" == "Windows" ]]; then
-  export WINDOWS_BUILD=1
-  export CC=gcc
-fi
+# NOTE: without CMAKE_INSTALL_PREFIX on Windows, files are installed
+# to c:\Program Files.
+cmake . \
+  -DCMAKE_INSTALL_PREFIX=/usr/local \
+  -DENABLE_PROGRAMS=OFF \
+  -DUNSAFE_BUILD=OFF \
+  -DGEN_FILES=OFF \
+  -DENABLE_TESTING=OFF
 
-# NOTE: The library is built statically unless SHARED environment
-# variable is set.
-make no_test
+make
 $SUDO make install


### PR DESCRIPTION
CMake-based deps were being installed to C:/Program Files by default on Windows instead of /usr/local.

Issue #13