### PR TITLE
fix: Install explicit toolchain for Windows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -203,11 +203,17 @@ jobs:
           # NOTE: pkg-config specifically must be installed because of
           # https://github.com/actions/runner-images/issues/5459, in which
           # there is a conflicting version that GitHub will not remove.
+          # NOTE: mingw-w64-x86_64-gcc must be installed because of conflicting
+          # GCC toolchains installed with Strawberry Perl, Git, and one more
+          # through Chocolatey.  None of these build clean executables that
+          # only depend on standard DLLs.
           pacman -Sy --noconfirm \
             diffutils \
             git \
             make \
+            mingw-w64-x86_64-gcc \
             nasm \
+            patch \
             pkg-config \
             yasm
 

--- a/build-scripts/08-ffmpeg.sh
+++ b/build-scripts/08-ffmpeg.sh
@@ -55,6 +55,12 @@ elif [[ "$RUNNER_OS" == "Windows" ]]; then
   PLATFORM_CONFIGURE_FLAGS="--target-os=mingw64"
 fi
 
+# Install a patch from https://github.com/FFmpeg/FFmpeg/commit/effadce6 to
+# resolve the binutils error "operand type mismatch for shr" on Windows,
+# described in https://github.com/msys2/MINGW-packages/issues/17946
+wget https://github.com/FFmpeg/FFmpeg/commit/effadce6.patch
+patch -p1 -i effadce6.patch
+
 if ! ./configure \
     --pkg-config-flags="--static" \
     --disable-ffplay \


### PR DESCRIPTION
In GitHub's VMs, there are already GCC toolchains installed with Strawberry Perl, Git, and one more through Chocolatey.  None of these build clean executables that only depend on standard DLLs.  Installing an explicitly mingw toolchain gives us a working toolchain that is higher in the path than these others.

Getting this far also exposed an error caused by an updated mingw binutils combined with some sign errors in ffmpeg's x86 assembly.  So this adds a patch from a newer version of ffmpeg to resolve that build failure.

Issue #13 