### PR TITLE
ci: Change test trigger

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,9 +16,11 @@
 name: Test
 
 # Runs when a PR is uploaded or revised.  Builds ffmpeg and ffprobe on all OS &
-# CPU combinations.
+# CPU combinations.  Uses pull_request_target rather than pull_request for
+# access to configuration variables.  Since no secrets are accessed or passed
+# to the build workflow, this is safe.  Only the release workflow uses secrets.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 # If another instance of this workflow is started for the same PR, cancel the
@@ -28,15 +30,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# NOTE: Set the repository secret ENABLE_DEBUG to enable debugging via tmate on
-# failure.
-# NOTE: Set the repository secret ENABLE_SELF_HOSTED to enable self-hosted
+# NOTE: Set the repository variable ENABLE_DEBUG to enable debugging via tmate
+# on failure.
+# NOTE: Set the repository variable ENABLE_SELF_HOSTED to enable self-hosted
 # runners such as linux-arm64.  This is set on the official repo, but forks
 # will have to opt in after setting up their own self-hosted runners.
 
 jobs:
   build:
     uses: ./.github/workflows/build.yaml
-    secrets:
-      ENABLE_DEBUG: ${{ secrets.ENABLE_DEBUG }}
-      ENABLE_SELF_HOSTED: ${{ secrets.ENABLE_SELF_HOSTED }}


### PR DESCRIPTION
This allows configuration variables to be access by pull request tests.  This is necessary to fix our broken use of secrets in a follow-up PR.