### PR TITLE
feat: Add macOS arm64 builds

### DIFF
--- a/build-matrix.json
+++ b/build-matrix.json
@@ -28,6 +28,12 @@
       "os_name": "linux",
       "target_arch": "arm64",
       "exe_ext": ""
+    },
+    {
+      "os": "self-hosted-macos-arm64",
+      "os_name": "osx",
+      "target_arch": "arm64",
+      "exe_ext": ""
     }
   ]
 }

--- a/build-scripts/01-libvpx.sh
+++ b/build-scripts/01-libvpx.sh
@@ -23,10 +23,10 @@ cd libvpx
 
 # NOTE: disabling unit tests and examples significantly reduces build
 # time (by 80% as tested on a Jetson Nano)
+# NOTE: --enable-runtime-cpu-detect fails on macOS arm64.
 ./configure \
   --enable-vp8 \
   --enable-vp9 \
-  --enable-runtime-cpu-detect \
   --disable-unit-tests \
   --disable-examples \
   --enable-static \

--- a/build-scripts/07-mbedtls.sh
+++ b/build-scripts/07-mbedtls.sh
@@ -22,6 +22,11 @@ git clone --depth 1 https://github.com/ARMmbed/mbedtls.git -b "$tag"
 
 cd mbedtls
 
+# Remove some compiler flags that cause build failures on macOS arm64.  This
+# can't be done through CMake variables, so we have to patch the source.
+sed -e 's/-Wdocumentation//' -e 's/-Wno-documentation-deprecated-sync//' \
+  -i.bk library/CMakeLists.txt
+
 # NOTE: without CMAKE_INSTALL_PREFIX on Windows, files are installed
 # to c:\Program Files.
 cmake . \


### PR DESCRIPTION
This uses a self-hosted runner in our lab to do macOS arm64 builds.