### PR TITLE
feat: Add macOS arm64 builds via GitHub Actions VM

### DIFF
--- a/build-matrix.json
+++ b/build-matrix.json
@@ -8,9 +8,17 @@
       "exe_ext": ""
     },
     {
-      "os": "macos-latest",
+      "comment": "Explicit macOS version 13 is required for explicit x64 CPU.",
+      "os": "macos-13",
       "os_name": "osx",
       "target_arch": "x64",
+      "exe_ext": ""
+    },
+    {
+      "comment": "Latest macOS version 13 is arm64 CPU.",
+      "os": "macos-latest",
+      "os_name": "osx",
+      "target_arch": "arm64",
       "exe_ext": ""
     },
     {
@@ -26,12 +34,6 @@
     {
       "os": "self-hosted-linux-arm64",
       "os_name": "linux",
-      "target_arch": "arm64",
-      "exe_ext": ""
-    },
-    {
-      "os": "self-hosted-macos-arm64",
-      "os_name": "osx",
       "target_arch": "arm64",
       "exe_ext": ""
     }


### PR DESCRIPTION
Replaces self-hosted Actions runner with GitHub-hosted VM.

Closes #40