### PR TITLE
feat: Build with Alpine for static Linux binaries

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -100,13 +100,14 @@ jobs:
 
     name: Build ${{ matrix.os_name }} ${{ matrix.target_arch }}
     runs-on: ${{ matrix.os }}
+    container:
+      image: ${{ matrix.container }}
+      # Access to the host filesystem is required to patch the environment for
+      # Alpine Linux support.  See the first Alpine step below for details.
+      volumes:
+        - /:/host
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          path: repo-src
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.push.head }}
-
       - name: Add msys2 to the Windows path
         if: runner.os == 'Windows'
         run: |
@@ -115,6 +116,38 @@ jobs:
           # mxschmitt/action-tmate.
           echo "C:\\msys64\\usr\\bin" >> "$GITHUB_PATH"
           echo "C:\\msys64\\mingw64\\bin" >> "$GITHUB_PATH"
+
+      # This is how we convince GitHub Actions Runner to run an Alpine Linux
+      # container.  We have to mask the fact that it's Alpine, install NodeJS,
+      # then patch the Alpine version of NodeJS in over the one that ships with
+      # GitHub Actions.  This is because GitHub doesn't officially support
+      # Alpine and because they hard-code the path to NodeJS in Node-based
+      # actions.
+      # See https://github.com/actions/runner/issues/801#issuecomment-2394425757
+      - name: Patch native Alpine NodeJS into Runner environment
+        if: runner.os == 'Linux'
+        run: |
+          apk add nodejs
+          sed -i "s:^ID=alpine:ID=NotpineForGHA:" /etc/os-release
+          # The first path here is for GitHub-hosted workflows, while the
+          # second path is correct for our self-hosted workflows using the
+          # myoung34/github-runner container.  The commands that follow this
+          # are correct so long as one of these paths exists.
+          cd /host/home/runner/runners/*/externals/ || cd /host/actions-runner/externals
+          rm -rf node20/*
+          mkdir node20/bin
+          ln -s /usr/bin/node node20/bin/node
+        shell: sh  # No bash in Alpine by default
+
+      - name: Install Alpine Linux deps
+        if: runner.os == 'Linux'
+        run: apk add bash npm sudo
+        shell: sh  # No bash in Alpine until after this command
+
+      - uses: actions/checkout@v4
+        with:
+          path: repo-src
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.push.head }}
 
       - name: Install OS packages
         run: ./repo-src/build-scripts/00-packages.sh

--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@ and you can verify that they haven't been tampered with.  The sums in the
 workflow logs, release notes, and the binaries should all match.
 You can read the details in the [workflow source][workflow].
 
-No third-party GitHub Actions have been used in this workflow, to protect
-against supply-chain attacks.
+Minimal third-party GitHub Actions have been used in this workflow, to protect
+against supply-chain attacks.  The following actions are used:
+
+ - mxschmitt/action-tmate: Used only on failure to debug failed builds, and
+   only if debug is configured at the repo level.
 
 
 # Triggering a build

--- a/build-matrix.json
+++ b/build-matrix.json
@@ -3,6 +3,7 @@
   "hosted": [
     {
       "os": "ubuntu-latest",
+      "container": "alpine:3.20",
       "os_name": "linux",
       "target_arch": "x64",
       "exe_ext": ""
@@ -33,6 +34,7 @@
   "selfHosted": [
     {
       "os": "self-hosted-linux-arm64",
+      "container": "arm64v8/alpine:3.20",
       "os_name": "linux",
       "target_arch": "arm64",
       "exe_ext": ""

--- a/build-scripts/00-packages.sh
+++ b/build-scripts/00-packages.sh
@@ -20,19 +20,39 @@ set -x
 if [[ "$RUNNER_OS" == "Linux" ]]; then
   # Install missing packages on Linux.
   #
-  # NOTE: Some of these are already on GitHub's VMs, but not our self-hosted
-  # runners.
-  sudo apt -y update
-  sudo apt -y upgrade
-  sudo apt -y install \
-    cmake \
-    curl \
-    nasm \
-    npm \
-    pkg-config \
-    yasm \
-    libffmpeg-nvenc-dev \
-    libvdpau-dev
+  # NOTE: In order to get a musl-based static build, we run our automated
+  # builds inside an Alpine Linux container, not directly on GitHub's Ubuntu
+  # VMs.
+  if repo-src/is-alpine.sh; then
+    sudo apk update
+    sudo apk upgrade
+    sudo apk add \
+      cmake \
+      curl \
+      diffutils \
+      g++ \
+      git \
+      libvdpau-dev \
+      linux-headers \
+      make \
+      nasm \
+      patch \
+      perl \
+      pkgconfig \
+      yasm
+  else
+    # This can be used by the developer on Ubuntu.  The builds may or may not
+    # work portably on other platforms.
+    sudo apt -y update
+    sudo apt -y upgrade
+    sudo apt -y install \
+      cmake \
+      curl \
+      libvdpau-dev \
+      nasm \
+      pkg-config \
+      yasm
+  fi
 
   # Use sudo in install commands on Linux.
   echo "SUDO=sudo" >> "$GITHUB_ENV"

--- a/is-alpine.sh
+++ b/is-alpine.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
-# Copyright 2021 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,20 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-set -x
+# Returns 0 if this is Alpine Linux.
 
-tag=$(repo-src/get-version.sh x264)
-git clone https://code.videolan.org/videolan/x264.git
-cd x264
-git checkout "$tag"
+OS_ID=$(cat /etc/os-release | grep ^ID= | cut -f 2 -d =)
+if [ "$OS_ID" = "alpine" -o "$OS_ID" = "NotpineForGHA" ]; then
+  # It is Alpine or the modified version we have to trick GitHub.
+  exit 0
+fi
 
-# NOTE: disable OpenCL-based features because it uses dlopen and can interfere
-# with static builds.
-./configure \
-  --disable-opencl \
-  --enable-static
-
-# Only build and install the static library.
-make libx264.a
-$SUDO make install-lib-static
+# It is not Alpine.
+exit 1


### PR DESCRIPTION
This uses an Alpine Linux container to build truly static Linux binaries that do not depend on glibc at runtime.

Alpine uses musl instead of glibc, which enables this fully static build.  With musl compiler wrappers in Ubuntu, you still end up importing glibc references through libstdc++.  And since x265 uses C++, we can't eliminate these in Ubuntu without dropping HEVC support. Using Alpine, with its musl-native environment, allows us to avoid glibc and build fully static Linux binaries.

Closes #28