### PR TITLE
fix: Silence nonsense macOS errors in GitHub Actions

### DIFF
--- a/build-scripts/00-packages.sh
+++ b/build-scripts/00-packages.sh
@@ -65,7 +65,7 @@ elif [[ "$RUNNER_OS" == "macOS" ]]; then
     x264 \
     x265 \
     xz \
-  ; do brew unlink $i || true; done
+  ; do brew unlink $i &>/dev/null || true; done
 
   # Use sudo in install commands on macOS.
   echo "SUDO=sudo" >> "$GITHUB_ENV"


### PR DESCRIPTION
Errors from "brew unlink" like "Error: No such keg: /opt/homebrew/Cellar/aom" are not important for us, since we are proactively removing homebrew packages that could potentially interfere with static linking.  But GitHub Actions sees "Error: " in the log and promotes this line to the summary for the job.

Since nothing in "brew unlink" output matters, silence that command completely.