### PR TITLE
feat: Build locally in Docker to streamline testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# These are created if you run the Dockerfile, since we mount this folder as
+# the home directory.
+.bash_history
+.sudo_as_admin_successful
+.wget-hsts
+
+# Editor swap files
+*~
+.*.sw*
+
+# A local build folder
+build

--- a/README.md
+++ b/README.md
@@ -64,13 +64,24 @@ container to avoid polluting your system.
 3. If you are using Linux, run `export RUNNER_OS=Linux`.
 4. If you are using macOS, run `export RUNNER_OS=macOS`.
 5. If you are using Linux, run `export RUNNER_OS=Windows`.
-6. Create a build folder.  For example, `mkdir -p build`.  It does not need to
+6. Set a temp path for `GITHUB_ENV`, for example `export GITHUB_ENV=/tmp/github.env`.
+7. Create a build folder.  For example, `mkdir -p build`.  It does not need to
    be in the git working directory.
-7. Change into that build directory.
-8. Create a symlink to the repo root called `repo-src` to emulate the structure
+8. Change into that build directory.
+9. Create a symlink to the repo root called `repo-src` to emulate the structure
    used by the workflow.  For example, if `build` is inside the repo, use
    `ln -s ../ repo-src`.
-9. Run the build scripts in [`build-scripts`][] in numerical order.
+10. Run the build scripts in [`build-scripts`][] in numerical order.
+
+
+# Docker builds
+
+You can run the above steps automatically in an Ubuntu Docker container with:
+
+```sh
+docker build -t static-ffmpeg-binaries /path/to/static-ffmpeg-binaries
+docker run -v /path/to/static-ffmpeg-binaries:/src static-ffmpeg-binaries /src/build.sh
+```
 
 
 [releases]: https://github.com/shaka-project/static-ffmpeg-binaries/releases

--- a/build-scripts/00-packages.sh
+++ b/build-scripts/00-packages.sh
@@ -48,9 +48,15 @@ if [[ "$RUNNER_OS" == "Linux" ]]; then
     sudo apt -y install \
       cmake \
       curl \
+      g++ \
+      git \
+      libffmpeg-nvenc-dev \
       libvdpau-dev \
+      make \
       nasm \
+      npm \
       pkg-config \
+      wget \
       yasm
   fi
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build everything, assuming we're inside an Ubuntu container.  This is useful
+# for quick automated builds and for testing build script changes.
+
+# Build with:
+#   rm -rf build
+#   docker run --rm -v $(pwd):/src -w /src ubuntu:24.04 /src/build.sh
+# Build outputs are:
+#   build/ffmpeg/ffmpeg
+#   build/ffmpeg/ffprobe
+
+# Fail on error
+set -e
+# Show commands as they are run
+set -x
+
+if [ ! -e build-scripts ]; then
+  echo "Must be run from inside the static-ffmpeg-binaries repo." 1>&2
+  exit 1
+fi
+
+# If run as root in a container, change to the ubuntu user.  This script only
+# supports Ubuntu as a container, for simplicity.
+if [[ $(id -u) == "0" ]]; then
+  # If we're on Ubuntu before 24.04, there's no default "ubuntu" user.
+  # This maps these older versions to the starting state of 24.04+.
+  groupadd -g 1000 ubuntu || true
+  useradd -u 1000 -g 1000 -m -d /home/ubuntu ubuntu || true
+
+  # Sudo is needed by the first build script, and vim is for interactive
+  # debugging and editing in the container.
+  apt -y update && apt -y upgrade && apt -y install vim sudo
+
+  # Make sudo work without a password.
+  echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+  # Create build/ and make it owned by ubuntu inside this Docker container, not
+  # the current user outside Docker.
+  rm -rf build
+  mkdir build
+  chown ubuntu build
+
+  if [ -z "$GITHUB_ENV" ]; then
+    # Running outside of GitHub Actions?  Set these important variables.
+    export GITHUB_ENV=/tmp/github.env
+    export SUDO=sudo
+    export RUNNER_OS=Linux
+  fi
+
+  # Preserve the environment (-p), which contains important variables like
+  # RUNNER_OS, etc.
+  exec su -p ubuntu "$0" "$@"
+fi
+
+# If we are running outside a container, we may not have hit the "root" branch
+# above.  Create the build/ folder if it doesn't exist.
+mkdir -p build
+
+# Set up the same symlink we get from our GitHub workflow, expected by the
+# build scripts.
+cd build
+ln -s ../ repo-src
+
+# Run each build script in order.
+for SCRIPT in ./repo-src/build-scripts/*; do
+  "$SCRIPT" || exit 1
+done

--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,9 @@ fi
 # supports Ubuntu as a container, for simplicity.
 if [[ $(id -u) == "0" ]]; then
   # If we're on Ubuntu before 24.04, there's no default "ubuntu" user.
-  # This maps these older versions to the starting state of 24.04+.
+  # Here we add the "ubuntu" group and the "ubuntu" user in that group,
+  # both with ID 1000.  This brings older versions, e.g. Ubuntu 22.04,
+  # to the starting state of Ubuntu 24.04+.
   groupadd -g 1000 ubuntu || true
   useradd -u 1000 -g 1000 -m -d /home/ubuntu ubuntu || true
 


### PR DESCRIPTION
When making changes to this process, it really helps to have a simple container environment to test changes.  This adds a script for a fully-automated build with standard Ubuntu containers to make it easier to check build script changes before deploying them to the repo.