### PR TITLE
ci: Correct versions file path in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,7 +95,7 @@ jobs:
           echo "" >> body.txt
 
           echo "Software versions:" >> body.txt
-          cat repo-src/.github/workflows/versions.txt | \
+          cat repo-src/versions.txt | \
             sed -e 's/^/ - /' >> body.txt
           echo "" >> body.txt
 


### PR DESCRIPTION
This was mistaken ever since we moved the file, but we haven't made any releases since then.  The effect of this bug would be to have the "versions" section of the release notes be empty.