### PR TITLE
ci: Fix concurrent test runs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ on:
 # old one.  If a PR is updated and a new test run is started, the old test run
 # will be cancelled automatically to conserve resources.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
   cancel-in-progress: true
 
 # NOTE: Set the repository variable ENABLE_DEBUG to enable debugging via tmate


### PR DESCRIPTION
The concurrency group expression for the test workflow would work for pull_request triggers, but not pull_request_target triggers.  This is because github.ref for pull_request is something like refs/pull/<pr_number>/merge, whereas for pull_request_target triggers it only references the target branch like refs/heads/main.

Instead we use github.event.number, which is the PR number, and fall back to github.run_id, which should be unique for manually-triggered runs of the workflow.