### PR TITLE
ci: Update upload-artifact

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -202,7 +202,7 @@ jobs:
       # This makes it possible to debug failures in the next step by
       # downloading binaries that fail the check for static linkage.
       - name: Upload assets as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: binaries${{ env.SUFFIX }}
           path: assets/*


### PR DESCRIPTION
The older version is deprecated and will stop working next month.