### PR TITLE
ci: Read build matrix JSON explicitly

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,7 +74,8 @@ jobs:
 
           // Use ENABLE_SELF_HOSTED to decide what the build matrix below
           // should include.
-          const {hosted, selfHosted} = require("${{ github.workspace }}/repo-src/build-matrix.json");
+          const buildMatrix = JSON.parse(fs.readFileSync("${{ github.workspace }}/repo-src/build-matrix.json"));
+          const {hosted, selfHosted} = buildMatrix;
           const matrix = enableSelfHosted ? hosted.concat(selfHosted) : hosted;
 
           // Output a JSON object consumed by the build matrix below.


### PR DESCRIPTION
Because we used require() to read build-matrix.json, the file could be replaced with build-matrix.json.js, allowing code injection into our CI pipelines. This fixes this vulnerability by reading the JSON text with the fs module, then explicitly parsing it, rather than relying on require().

This exploit was discovered by a researcher, and the researcher's activity was spotted within hours.  Workflows were immediately suspended.  No evidence has been found of any tampering in this repository or its releases.

Issue #57