### PR TITLE
ci: Do not persist credentials after checkout

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,6 +55,7 @@ jobs:
         with:
           path: repo-src
           ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
 
       - name: Configure Build Matrix
         id: configure
@@ -150,6 +151,7 @@ jobs:
         with:
           path: repo-src
           ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
 
       - name: Install OS packages
         run: ./repo-src/build-scripts/00-packages.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,7 @@ jobs:
         with:
           path: repo-src
           ref: ${{ github.ref }}
+          persist-credentials: false
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
See actions/checkout#485 and https://johnstawinski.com/2024/01/11/playing-with-fire-how-we-executed-a-critical-supply-chain-attack-on-pytorch/

In short, it is a terrible idea to persist even our default credentials after checkout. There's no call for that, so we will now set `persist-credentials: false` on all checkout actions.