### PR TITLE
feat: ffmpeg 8.0.3 and x265 4.2

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -2,7 +2,7 @@ ffmpeg: n8.0.3
 libvpx: v1.16.0
 svt-av1: v3.1.2
 x264: b35605ac
-x265: 4.1
+x265: 4.2
 lame: 3.100
 opus: v1.5.2
 mbedtls: v3.4.1

--- a/versions.txt
+++ b/versions.txt
@@ -1,4 +1,4 @@
-ffmpeg: n8.0.1
+ffmpeg: n8.0.3
 libvpx: v1.16.0
 svt-av1: v3.1.2
 x264: b35605ac


### PR DESCRIPTION
 - Bump ffmpeg to 8.0.3 to deal with recent vulnerabilities
   - https://www.cve.org/CVERecord?id=CVE-2026-8461
   - https://www.cve.org/CVERecord?id=CVE-2026-30999
   - https://www.cve.org/CVERecord?id=CVE-2025-67306

 - Bump x265 to 4.2 for CMake 4 compatibility

Closes #72